### PR TITLE
feat: Add `LedgerAccountsProvider` component

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
   "packages/assets": "0.2.0",
   "packages/cloud-core": "1.1.0",
-  "packages/cloud-react": "0.2.0",
+  "packages/cloud-react": "0.2.1",
   "packages/utils": "0.1.0",
   "builder": "0.2.0",
   "sandbox": "0.2.0"

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,7 +2,7 @@
   "packages/assets": "0.2.0",
   "packages/cloud-core": "1.1.0",
   "packages/cloud-react": "0.2.1",
-  "packages/utils": "0.1.0",
+  "packages/utils": "0.1.1",
   "builder": "0.2.0",
   "sandbox": "0.2.0"
 }

--- a/packages/cloud-react/lib/connect/LedgerAccountsProvider/defaults.ts
+++ b/packages/cloud-react/lib/connect/LedgerAccountsProvider/defaults.ts
@@ -1,0 +1,14 @@
+// Copyright 2023 @polkadot-cloud/library authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function,  no-unused-vars */
+
+import { LedgerAccountsContextInterface } from "./types";
+
+export const defaultLedgerAccountsContext: LedgerAccountsContextInterface = {
+  ledgerAccountExists: (address) => false,
+  addLedgerAccount: (address, index) => null,
+  removeLedgerAccount: (address, notify) => {},
+  renameLedgerAccount: (address, newName) => {},
+  getLedgerAccount: (address) => null,
+  ledgerAccounts: [],
+};

--- a/packages/cloud-react/lib/connect/LedgerAccountsProvider/defaults.ts
+++ b/packages/cloud-react/lib/connect/LedgerAccountsProvider/defaults.ts
@@ -6,8 +6,8 @@ import { LedgerAccountsContextInterface } from "./types";
 
 export const defaultLedgerAccountsContext: LedgerAccountsContextInterface = {
   ledgerAccountExists: (address) => false,
-  addLedgerAccount: (address, index) => null,
-  removeLedgerAccount: (address, notify) => {},
+  addLedgerAccount: (address, index, callback) => null,
+  removeLedgerAccount: (address, callback) => {},
   renameLedgerAccount: (address, newName) => {},
   getLedgerAccount: (address) => null,
   ledgerAccounts: [],

--- a/packages/cloud-react/lib/connect/LedgerAccountsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/LedgerAccountsProvider/index.tsx
@@ -1,10 +1,12 @@
 // Copyright 2023 @polkadot-cloud/library authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { ReactNode, createContext, useContext, useRef, useState } from "react";
+import { createContext, useContext, useRef, useState } from "react";
 import { defaultLedgerAccountsContext } from "./defaults";
-import { LedgerAccountsContextInterface } from "./types";
-import { AnyFunction, AnyJson } from "lib/utils/types";
+import {
+  LedgerAccountsContextInterface,
+  LedgerAccountsProviderProps,
+} from "./types";
 import { LedgerAccount } from "../types";
 import {
   getLocalLedgerAccounts,
@@ -23,11 +25,7 @@ export const useLedgerAccounts = () => useContext(LedgerAccountsContext);
 export const LedgerAccountsProvider = ({
   children,
   network,
-}: {
-  t: AnyJson;
-  children: ReactNode;
-  network: string;
-}) => {
+}: LedgerAccountsProviderProps) => {
   // Store the fetched ledger accounts.
   const [ledgerAccounts, setLedgerAccountsState] = useState<LedgerAccount[]>(
     getLocalLedgerAccounts(network)
@@ -45,7 +43,7 @@ export const LedgerAccountsProvider = ({
   const addLedgerAccount = (
     address: string,
     index: number,
-    callback?: AnyFunction
+    callback?: () => void
   ) => {
     let newLedgerAccounts = getLocalLedgerAccounts();
 
@@ -91,7 +89,7 @@ export const LedgerAccountsProvider = ({
   };
 
   // Removes a Ledger account from state and local storage.
-  const removeLedgerAccount = (address: string, callback?: AnyFunction) => {
+  const removeLedgerAccount = (address: string, callback?: () => void) => {
     // Remove th account from local storage records
     const newLedgerAccounts = getLocalLedgerAccounts().filter((account) => {
       if (account.address !== address) return true;

--- a/packages/cloud-react/lib/connect/LedgerAccountsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/LedgerAccountsProvider/index.tsx
@@ -1,0 +1,177 @@
+// Copyright 2023 @polkadot-cloud/library authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { ReactNode, createContext, useContext, useRef, useState } from "react";
+import { defaultLedgerAccountsContext } from "./defaults";
+import { LedgerAccountsContextInterface } from "./types";
+import { AnyFunction, AnyJson } from "lib/utils/types";
+import { LedgerAccount } from "../types";
+import {
+  getLocalLedgerAccounts,
+  getLocalLedgerAddresses,
+  isLocalLedgerAccount,
+  renameLocalLedgerAddress,
+} from "./utils";
+import { setStateWithRef } from "@polkadot-cloud/utils";
+import { useEffectIgnoreInitial } from "lib/base/hooks/useEffectIgnoreInitial";
+
+export const LedgerAccountsContext =
+  createContext<LedgerAccountsContextInterface>(defaultLedgerAccountsContext);
+
+export const useLedgerAccounts = () => useContext(LedgerAccountsContext);
+
+export const LedgerAccountsProvider = ({
+  children,
+  network,
+}: {
+  t: AnyJson;
+  children: ReactNode;
+  network: string;
+}) => {
+  // Store the fetched ledger accounts.
+  const [ledgerAccounts, setLedgerAccountsState] = useState<LedgerAccount[]>(
+    getLocalLedgerAccounts(network)
+  );
+  const ledgerAccountsRef = useRef(ledgerAccounts);
+
+  // Check if a Ledger address exists in imported addresses.
+  const ledgerAccountExists = (address: string) => {
+    return !!getLocalLedgerAccounts().find((account) =>
+      isLocalLedgerAccount(network, account, address)
+    );
+  };
+
+  // Adds a ledger address to the list of fetched addresses.
+  const addLedgerAccount = (
+    address: string,
+    index: number,
+    callback?: AnyFunction
+  ) => {
+    let newLedgerAccounts = getLocalLedgerAccounts();
+
+    const ledgerAddress = getLocalLedgerAddresses().find((a) =>
+      isLocalLedgerAccount(network, a, address)
+    );
+
+    if (
+      ledgerAddress &&
+      !newLedgerAccounts.find((account) =>
+        isLocalLedgerAccount(network, account, address)
+      )
+    ) {
+      const newAccount = {
+        address,
+        network,
+        name: ledgerAddress.name,
+        source: "ledger",
+        index,
+      };
+
+      // Update the full list of local ledger accounts with new entry.
+      newLedgerAccounts = [...newLedgerAccounts].concat(newAccount);
+      localStorage.setItem(
+        "ledger_accounts",
+        JSON.stringify(newLedgerAccounts)
+      );
+
+      // Store only those accounts on the current network in state.
+      setStateWithRef(
+        newLedgerAccounts.filter((account) => account.network === network),
+        setLedgerAccountsState,
+        ledgerAccountsRef
+      );
+
+      // Handle optional callback function.
+      if (typeof callback === "function") {
+        callback();
+      }
+      return newAccount;
+    }
+    return null;
+  };
+
+  // Removes a Ledger account from state and local storage.
+  const removeLedgerAccount = (address: string, callback?: AnyFunction) => {
+    // Remove th account from local storage records
+    const newLedgerAccounts = getLocalLedgerAccounts().filter((account) => {
+      if (account.address !== address) return true;
+      if (account.network !== network) return true;
+      return false;
+    });
+    if (!newLedgerAccounts.length) localStorage.removeItem("ledger_accounts");
+    else
+      localStorage.setItem(
+        "ledger_accounts",
+        JSON.stringify(newLedgerAccounts)
+      );
+
+    // Update state with the new list of accounts.
+    setStateWithRef(
+      newLedgerAccounts.filter((account) => account.network === network),
+      setLedgerAccountsState,
+      ledgerAccountsRef
+    );
+
+    // Handle optional callback function.
+    if (typeof callback === "function") {
+      callback();
+    }
+  };
+
+  // Renames an imported ledger account.
+  const renameLedgerAccount = (address: string, newName: string) => {
+    // Update the local storage records.
+    const newLedgerAccounts = getLocalLedgerAccounts().map((account) =>
+      isLocalLedgerAccount(network, account, address)
+        ? {
+            ...account,
+            name: newName,
+          }
+        : account
+    );
+    renameLocalLedgerAddress(address, newName, network);
+    localStorage.setItem("ledger_accounts", JSON.stringify(newLedgerAccounts));
+
+    // Update state with the new list of accounts.
+    setStateWithRef(
+      newLedgerAccounts.filter((account) => account.network === network),
+      setLedgerAccountsState,
+      ledgerAccountsRef
+    );
+  };
+
+  // Gets an imported address along with its Ledger metadata.
+  const getLedgerAccount = (address: string) => {
+    const localLedgerAccounts = getLocalLedgerAccounts();
+    if (!localLedgerAccounts) return null;
+    return (
+      localLedgerAccounts.find((account) =>
+        isLocalLedgerAccount(network, account, address)
+      ) || null
+    );
+  };
+
+  // Refresh imported ledger accounts on network change.
+  useEffectIgnoreInitial(() => {
+    setStateWithRef(
+      getLocalLedgerAccounts(network),
+      setLedgerAccountsState,
+      ledgerAccountsRef
+    );
+  }, [network]);
+
+  return (
+    <LedgerAccountsContext.Provider
+      value={{
+        ledgerAccountExists,
+        getLedgerAccount,
+        addLedgerAccount,
+        removeLedgerAccount,
+        renameLedgerAccount,
+        ledgerAccounts: ledgerAccountsRef.current,
+      }}
+    >
+      {children}
+    </LedgerAccountsContext.Provider>
+  );
+};

--- a/packages/cloud-react/lib/connect/LedgerAccountsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/LedgerAccountsProvider/index.tsx
@@ -15,7 +15,7 @@ import {
   renameLocalLedgerAddress,
 } from "./utils";
 import { setStateWithRef } from "@polkadot-cloud/utils";
-import { useEffectIgnoreInitial } from "lib/base/hooks/useEffectIgnoreInitial";
+import { useEffectIgnoreInitial } from "../../base/hooks/useEffectIgnoreInitial";
 
 export const LedgerAccountsContext =
   createContext<LedgerAccountsContextInterface>(defaultLedgerAccountsContext);

--- a/packages/cloud-react/lib/connect/LedgerAccountsProvider/types.ts
+++ b/packages/cloud-react/lib/connect/LedgerAccountsProvider/types.ts
@@ -1,9 +1,10 @@
 // Copyright 2023 @polkadot-cloud/library authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import { ReactNode } from "react";
 import { LedgerAccount } from "../types";
 
-export type LedgerAccountsContextInterface = {
+export interface LedgerAccountsContextInterface {
   ledgerAccountExists: (a: string) => boolean;
   addLedgerAccount: (
     a: string,
@@ -14,7 +15,12 @@ export type LedgerAccountsContextInterface = {
   renameLedgerAccount: (a: string, name: string) => void;
   getLedgerAccount: (a: string) => LedgerAccount | null;
   ledgerAccounts: LedgerAccount[];
-};
+}
+
+export interface LedgerAccountsProviderProps {
+  children: ReactNode;
+  network: string;
+}
 
 export interface LedgerAddress {
   address: string;

--- a/packages/cloud-react/lib/connect/LedgerAccountsProvider/types.ts
+++ b/packages/cloud-react/lib/connect/LedgerAccountsProvider/types.ts
@@ -7,13 +7,13 @@ import { LedgerAccount } from "../types";
 export interface LedgerAccountsContextInterface {
   ledgerAccountExists: (a: string) => boolean;
   addLedgerAccount: (
-    a: string,
-    i: number,
+    address: string,
+    index: number,
     callback?: () => void
   ) => LedgerAccount | null;
-  removeLedgerAccount: (a: string, callback?: () => void) => void;
-  renameLedgerAccount: (a: string, name: string) => void;
-  getLedgerAccount: (a: string) => LedgerAccount | null;
+  removeLedgerAccount: (address: string, callback?: () => void) => void;
+  renameLedgerAccount: (address: string, name: string) => void;
+  getLedgerAccount: (address: string) => LedgerAccount | null;
   ledgerAccounts: LedgerAccount[];
 }
 

--- a/packages/cloud-react/lib/connect/LedgerAccountsProvider/types.ts
+++ b/packages/cloud-react/lib/connect/LedgerAccountsProvider/types.ts
@@ -1,0 +1,25 @@
+// Copyright 2023 @polkadot-cloud/library authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { LedgerAccount } from "../types";
+
+export type LedgerAccountsContextInterface = {
+  ledgerAccountExists: (a: string) => boolean;
+  addLedgerAccount: (
+    a: string,
+    i: number,
+    callback?: () => void
+  ) => LedgerAccount | null;
+  removeLedgerAccount: (a: string, callback?: () => void) => void;
+  renameLedgerAccount: (a: string, name: string) => void;
+  getLedgerAccount: (a: string) => LedgerAccount | null;
+  ledgerAccounts: LedgerAccount[];
+};
+
+export interface LedgerAddress {
+  address: string;
+  index: number;
+  name: string;
+  network: string;
+  pubKey: string;
+}

--- a/packages/cloud-react/lib/connect/LedgerAccountsProvider/useLedgerAccounts.tsx
+++ b/packages/cloud-react/lib/connect/LedgerAccountsProvider/useLedgerAccounts.tsx
@@ -1,0 +1,7 @@
+// Copyright 2023 @polkadot-cloud/library authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { useContext } from "react";
+import { LedgerAccountsContext } from ".";
+
+export const useLedgerAccounts = () => useContext(LedgerAccountsContext);

--- a/packages/cloud-react/lib/connect/LedgerAccountsProvider/utils.ts
+++ b/packages/cloud-react/lib/connect/LedgerAccountsProvider/utils.ts
@@ -1,0 +1,61 @@
+// Copyright 2023 @polkadot-cloud/library authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { localStorageOrDefault } from "@polkadot-cloud/utils";
+import { LedgerAccount } from "../types";
+import { MaybeString } from "../../utils/types";
+import { LedgerAddress } from "./types";
+
+// Gets imported Ledger accounts from local storage.
+export const getLocalLedgerAccounts = (network?: string): LedgerAccount[] => {
+  const localAddresses = localStorageOrDefault(
+    "ledger_accounts",
+    [],
+    true
+  ) as LedgerAccount[];
+
+  return network
+    ? localAddresses.filter((a) => a.network === network)
+    : localAddresses;
+};
+
+// Gets whether an address is a local Ledger account.
+export const isLocalLedgerAccount = (
+  network: string,
+  account: { address: MaybeString; network: string },
+  address: string
+) => account.address === address && account.network === network;
+
+// Gets saved ledger addresses from local storage.
+export const getLocalLedgerAddresses = (network?: string) => {
+  const localAddresses = localStorageOrDefault(
+    "ledger_addresses",
+    [],
+    true
+  ) as LedgerAddress[];
+
+  return network
+    ? localAddresses.filter((a) => a.network === network)
+    : localAddresses;
+};
+
+// Renames a record from local ledger addresses.
+export const renameLocalLedgerAddress = (
+  address: string,
+  name: string,
+  network: string
+) => {
+  const localLedger = (
+    localStorageOrDefault("ledger_addresses", [], true) as LedgerAddress[]
+  )?.map((i) =>
+    !(i.address === address && i.network === network)
+      ? i
+      : {
+          ...i,
+          name,
+        }
+  );
+  if (localLedger) {
+    localStorage.setItem("ledger_addresses", JSON.stringify(localLedger));
+  }
+};

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -42,8 +42,8 @@
     "@polkadot-cloud/core": "^1.1.0",
     "@polkadot-cloud/utils": "^0.1.0",
     "@polkadot/keyring": "^12.6.2",
-    "@polkadot/util": "^12.5.1",
-    "@polkadot/util-crypto": "^12.5.1",
+    "@polkadot/util": "^12.6.2",
+    "@polkadot/util-crypto": "^12.6.2",
     "framer-motion": "^10.16.16",
     "react-error-boundary": "^4.0.12"
   }

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-react",
   "license": "GPL-3.0-only",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "contributors": [
     "Ross Bulat<ross@parity.io>",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-utils",
   "license": "GPL-3.0-only",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "contributors": [
     "Ross Bulat<ross@parity.io>",
     "Nikolaos Kontakis<wirednkod@gmail.com>"
@@ -26,11 +26,11 @@
   },
   "dependencies": {
     "@polkadot/keyring": "^12.6.2",
-    "@polkadot/util": "^12.5.1",
+    "@polkadot/util": "^12.6.2",
     "bignumber.js": "^9.1.1"
   },
   "peerDependencies": {
     "@polkadot/keyring": "^12.6.2",
-    "@polkadot/util": "^12.5.1"
+    "@polkadot/util": "^12.6.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1073,7 +1073,7 @@
     rxjs "^7.8.1"
     tslib "^2.6.2"
 
-"@polkadot/util-crypto@12.6.2", "@polkadot/util-crypto@^12.5.1", "@polkadot/util-crypto@^12.6.1":
+"@polkadot/util-crypto@12.6.2", "@polkadot/util-crypto@^12.6.1", "@polkadot/util-crypto@^12.6.2":
   version "12.6.2"
   resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-12.6.2.tgz#d2d51010e8e8ca88951b7d864add797dad18bbfc"
   integrity sha512-FEWI/dJ7wDMNN1WOzZAjQoIcCP/3vz3wvAp5QQm+lOrzOLj0iDmaIGIcBkz8HVm3ErfSe/uKP0KS4jgV/ib+Mg==
@@ -1102,7 +1102,7 @@
     bn.js "^5.2.1"
     tslib "^2.6.2"
 
-"@polkadot/util@12.6.2", "@polkadot/util@^12.5.1", "@polkadot/util@^12.6.1":
+"@polkadot/util@12.6.2", "@polkadot/util@^12.5.1", "@polkadot/util@^12.6.1", "@polkadot/util@^12.6.2":
   version "12.6.2"
   resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-12.6.2.tgz#9396eff491221e1f0fd28feac55fc16ecd61a8dc"
   integrity sha512-l8TubR7CLEY47240uki0TQzFvtnxFIO7uI/0GoWzpYD/O62EIAMRsuY01N4DuwgKq2ZWD59WhzsLYmA5K6ksdw==


### PR DESCRIPTION
This PR adds a provider that provides CRUD operations for Ledger accounts.

On the staking dashboard, interacting with a Ledger device requires this provider and another `LedgerHardwareProvider`, that uses an accompanying static class to interact with the device.

As a part 1 of 2, I would like to stop using `LedgerAccountsProvider` on the staking dashboard and migrate to this one.

Part 2 would see the hardware provider moved to Polkadot Cloud. Once this is done we can start sandboxing & testing, and finally add ledger docs & add the providers to the recipe.