### PR TITLE
feat: use `ValidatorEntry` for community list

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/assets": "0.2.0",
+  "packages/assets": "0.2.1",
   "packages/cloud-core": "1.1.0",
   "packages/cloud-react": "0.2.0",
   "packages/utils": "0.1.0",

--- a/packages/assets/lib/types.ts
+++ b/packages/assets/lib/types.ts
@@ -22,8 +22,16 @@ export interface HardwareConfig {
 // The supported chains for validators.
 export type ValidatorSupportedChains = "polkadot" | "kusama" | "westend";
 
+// Icon record structure.
+export type ExtensionIconRecords = Record<string, ExtensionIcon>;
+
+export type ExtensionIcon = FC<{
+  style?: CSSProperties;
+  className?: string;
+}>;
+
 // Structure for a validator entity.
-export interface ValidatorConfig {
+export interface ValidatorEntry {
   name: string;
   thumbnail: string;
   bio: string;
@@ -35,14 +43,6 @@ export interface ValidatorConfig {
     [K in ValidatorSupportedChains]: string[];
   }>;
 }
-
-// Icon record structure.
-export type ExtensionIconRecords = Record<string, ExtensionIcon>;
-
-export type ExtensionIcon = FC<{
-  style?: CSSProperties;
-  className?: string;
-}>;
 
 // Global types.
 declare global {

--- a/packages/assets/lib/validators/index.tsx
+++ b/packages/assets/lib/validators/index.tsx
@@ -1,7 +1,9 @@
 /* @license Copyright 2023 @polkadot-cloud/library authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
-export const ValidatorCommunity = [
+import { ValidatorEntry } from "lib/types";
+
+export const ValidatorCommunity: ValidatorEntry[] = [
   {
     name: "🍁 HIGH/STAKE 🥩",
     thumbnail: "Highstake",

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-assets",
   "license": "GPL-3.0-only",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "contributors": [
     "Ross Bulat<ross@parity.io>",

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -38,7 +38,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "@polkadot-cloud/assets": "0.2.1",
+    "@polkadot-cloud/assets": "0.2.0",
     "@polkadot-cloud/core": "^1.1.0",
     "@polkadot-cloud/utils": "^0.1.0",
     "@polkadot/keyring": "^12.6.2",

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -38,7 +38,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "@polkadot-cloud/assets": "0.2.0",
+    "@polkadot-cloud/assets": "0.2.1",
     "@polkadot-cloud/core": "^1.1.0",
     "@polkadot-cloud/utils": "^0.1.0",
     "@polkadot/keyring": "^12.6.2",


### PR DESCRIPTION
`ValidatorCommunity` was not typed, resulting in the type not being bundled in the resulting package. This PR fixes this.