### PR TITLE
feat(refactor): Refactor `connectActiveExtensions` to limit re-renders

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -22,3 +22,4 @@ postcss.config.js
 *.yml
 LICENSE
 README.md
+CHANGELOG.md

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,8 +6,8 @@
   },
   "extends": [
     "plugin:import/recommended",
-    "plugin:@typescript-eslint/recommended",
     "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended"
   ],
   "plugins": ["@typescript-eslint", "import", "unused-imports"],

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,4 @@
 **/tstsconfig.tsbuildinfo
 README.md
 *CODEOWNERS*
+CHANGELOG.md

--- a/packages/cloud-react/.eslintrc.json
+++ b/packages/cloud-react/.eslintrc.json
@@ -6,8 +6,7 @@
   },
   "extends": [
     "../../.eslintrc.json", 
-    "plugin:react/recommended", 
-    "plugin:@typescript-eslint/recommended"
+    "plugin:react/recommended"
   ],
   "plugins": ["react", "@typescript-eslint", "prefer-arrow-functions"],
   "rules": {

--- a/packages/cloud-react/.eslintrc.json
+++ b/packages/cloud-react/.eslintrc.json
@@ -4,7 +4,11 @@
       "version": "detect"
     }
   },
-  "extends": ["../../.eslintrc.json", "plugin:react/recommended"],
+  "extends": [
+    "../../.eslintrc.json", 
+    "plugin:react/recommended", 
+    "plugin:@typescript-eslint/recommended"
+  ],
   "plugins": ["react", "@typescript-eslint", "prefer-arrow-functions"],
   "rules": {
     "react/jsx-filename-extension": [

--- a/packages/cloud-react/.eslintrc.json
+++ b/packages/cloud-react/.eslintrc.json
@@ -4,10 +4,7 @@
       "version": "detect"
     }
   },
-  "extends": [
-    "../../.eslintrc.json", 
-    "plugin:react/recommended"
-  ],
+  "extends": ["../../.eslintrc.json", "plugin:react/recommended"],
   "plugins": ["react", "@typescript-eslint", "prefer-arrow-functions"],
   "rules": {
     "react/jsx-filename-extension": [

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/Extensions.ts
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/Extensions.ts
@@ -146,6 +146,7 @@ export class Extensions {
       return all;
     } catch (err) {
       // Return an empty array if an error occurs.
+       console.error("Error during 'enable' and format call for Extensions: ", err);
       return [];
     }
   };

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/Extensions.ts
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/Extensions.ts
@@ -1,0 +1,151 @@
+// Copyright 2023 @polkadot-cloud/library authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { localStorageOrDefault } from "@polkadot-cloud/utils";
+import {
+  ExtensionEnableResult,
+  ExtensionEnableResults,
+  RawExtensionEnable,
+  RawExtensions,
+} from "../types";
+import {
+  ExtensionAccount,
+  ExtensionInterface,
+} from "../ExtensionsProvider/types";
+
+export class Extensions {
+  // Gets a map of extensions with their enable functions from `injectedWeb3`.
+  static getFromIds = (extensionIds: string[]): RawExtensions => {
+    const rawExtensions = new Map<string, RawExtensionEnable>();
+
+    extensionIds.forEach(async (id) => {
+      if (this.isLocal(id)) {
+        const { enable } = window.injectedWeb3[id];
+
+        if (enable !== undefined && typeof enable === "function") {
+          rawExtensions.set(id, enable);
+        } else {
+          this.removeFromLocal(id);
+        }
+      }
+    });
+    return rawExtensions;
+  };
+
+  // Calls `enable` for the provided extensions.
+  static enable = async (
+    extensions: RawExtensions,
+    dappName: string
+  ): Promise<PromiseSettledResult<ExtensionInterface>[]> => {
+    const results = await Promise.allSettled(
+      Object.values(extensions).map((enable) => enable(dappName))
+    );
+    return results;
+  };
+
+  // Formats the results of an extension's `enable` function.
+  static formatEnabled = (
+    extensions: RawExtensions,
+    results: PromiseSettledResult<ExtensionInterface>[]
+  ): ExtensionEnableResults => {
+    // Accumulate resulting extensions state after attempting to enable.
+    const extensionsState = new Map<string, ExtensionEnableResult>();
+
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      const id = extensions.keys()[i];
+
+      if (result.status === "fulfilled") {
+        extensionsState.set(id, {
+          extension: result.value,
+          connected: true,
+        });
+      } else if (result.status === "rejected") {
+        extensionsState.set(id, {
+          connected: false,
+          error: result.reason,
+        });
+      }
+    }
+    return extensionsState;
+  };
+
+  // Return successfully connected extensions.
+  static connected = (
+    extensions: ExtensionEnableResults
+  ): ExtensionEnableResults => {
+    return new Map(
+      Array.from(extensions.entries()).filter(([, state]) => state.connected)
+    );
+  };
+
+  static withError = (
+    extensions: ExtensionEnableResults
+  ): ExtensionEnableResults => {
+    return new Map(
+      Array.from(extensions.entries()).filter(([, state]) => !state.connected)
+    );
+  };
+
+  // Calls `enable` and formats the results of an extension's `enable` function.
+  static getAllAccounts = async (
+    extensions: ExtensionEnableResults
+  ): Promise<ExtensionAccount[]> => {
+    const results = await Promise.allSettled(
+      Array.from(extensions.values()).map(({ extension }) =>
+        extension.accounts.get()
+      )
+    );
+
+    const all: ExtensionAccount[] = [];
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (result.status === "fulfilled") {
+        all.push(...result.value);
+      }
+    }
+    return all;
+  };
+
+  // Check if an extension exists in local `active_extensions`.
+  static isLocal = (id: string): boolean => {
+    const current = localStorageOrDefault<string[]>(
+      `active_extensions`,
+      [],
+      true
+    );
+    let isLocal = false;
+    if (Array.isArray(current)) {
+      isLocal = current.find((l) => l === id) !== undefined;
+    }
+    return !!isLocal;
+  };
+
+  // Adds an extension to local `active_extensions`.
+  static addToLocal = (id: string): void => {
+    const current = localStorageOrDefault<string[]>(
+      `active_extensions`,
+      [],
+      true
+    );
+    if (Array.isArray(current)) {
+      if (!current.includes(id)) {
+        current.push(id);
+        localStorage.setItem("active_extensions", JSON.stringify(current));
+      }
+    }
+  };
+
+  // Removes extension from local `active_extensions`.
+  static removeFromLocal = (id: string): void => {
+    let current = localStorageOrDefault<string[]>(
+      `active_extensions`,
+      [],
+      true
+    );
+    if (Array.isArray(current)) {
+      current = current.filter((localId: string) => localId !== id);
+      localStorage.setItem("active_extensions", JSON.stringify(current));
+    }
+  };
+}

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/Extensions.ts
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/Extensions.ts
@@ -13,6 +13,7 @@ import {
   ExtensionInterface,
 } from "../ExtensionsProvider/types";
 
+// A static class to manage the discovery and importing of extensions.
 export class Extensions {
   // Gets a map of extensions with their enable functions from `injectedWeb3`.
   static getFromIds = (extensionIds: string[]): RawExtensions => {

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/Extensions.ts
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/Extensions.ts
@@ -45,7 +45,7 @@ export class Extensions {
       );
       return results;
     } catch (err) {
-       console.error("Error during 'enable' call for Extensions: ", err);
+      console.error("Error during 'enable' call for Extensions: ", err);
       // Return an empty array if an error occurs.
       return [];
     }
@@ -147,7 +147,10 @@ export class Extensions {
       return all;
     } catch (err) {
       // Return an empty array if an error occurs.
-       console.error("Error during 'enable' and format call for Extensions: ", err);
+      console.error(
+        "Error during 'enable' and format call for Extensions: ",
+        err
+      );
       return [];
     }
   };

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/Extensions.ts
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/Extensions.ts
@@ -45,6 +45,7 @@ export class Extensions {
       );
       return results;
     } catch (err) {
+       console.error("Error during 'enable' call for Extensions: ", err);
       // Return an empty array if an error occurs.
       return [];
     }

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/defaults.ts
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/defaults.ts
@@ -7,7 +7,6 @@ import { ExtensionAccountsContextInterface } from "./types";
 export const defaultExtensionAccountsContext: ExtensionAccountsContextInterface =
   {
     connectExtensionAccounts: () => Promise.resolve(false),
-    forgetAccounts: (accounts) => {},
     extensionAccountsSynced: "unsynced",
     extensionAccounts: [],
   };

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/defaults.ts
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/defaults.ts
@@ -14,7 +14,7 @@ export const defaultExtensionAccountsContext: ExtensionAccountsContextInterface 
 export const defaultHandleImportExtension = {
   newAccounts: [],
   meta: {
-    accountsToForget: [],
+    accountsToRemove: [],
     removedActiveAccount: null,
   },
 };

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/defaults.ts
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/defaults.ts
@@ -15,6 +15,7 @@ export const defaultExtensionAccountsContext: ExtensionAccountsContextInterface 
 export const defaultHandleImportExtension = {
   newAccounts: [],
   meta: {
+    accountsToForget: [],
     removedActiveAccount: null,
   },
 };

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
@@ -20,7 +20,11 @@ import { useEffectIgnoreInitial } from "../../base/hooks/useEffectIgnoreInitial"
 import { initPolkadotSnap } from "./snap";
 import { SnapNetworks } from "@chainsafe/metamask-polkadot-types";
 import { Extensions } from "./Extensions";
-import { getActiveAccountLocal } from "./utils";
+import {
+  connectActiveExtensionAccount,
+  getActiveAccountLocal,
+  getActiveExtensionAccount,
+} from "./utils";
 
 export const ExtensionAccountsContext =
   createContext<ExtensionAccountsContextInterface>(
@@ -36,11 +40,7 @@ export const ExtensionAccountsProvider = ({
   setActiveAccount,
   onExtensionEnabled,
 }: ExtensionAccountsProviderProps) => {
-  const {
-    handleImportExtension,
-    getActiveExtensionAccount,
-    connectActiveExtensionAccount,
-  } = useImportExtension();
+  const { handleImportExtension } = useImportExtension();
 
   const {
     extensionsStatus,

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
@@ -144,7 +144,7 @@ export const ExtensionAccountsProvider = ({
       updateInitialisedExtensions(id);
     });
 
-    addExtensionAccounts({ add: initialAccounts, remove: [] });
+    updateExtensionAccounts({ add: initialAccounts, remove: [] });
 
     if (activeAccountInInitial) {
       connectActiveExtensionAccount(activeAccountInInitial, connectToAccount);
@@ -174,7 +174,7 @@ export const ExtensionAccountsProvider = ({
       );
 
       // Update added and removed accounts.
-      addExtensionAccounts({ add: newAccounts, remove: accountsToForget });
+      updateExtensionAccounts({ add: newAccounts, remove: accountsToForget });
     };
 
     // Try to subscribe to accounts for each connected extension.
@@ -247,7 +247,7 @@ export const ExtensionAccountsProvider = ({
             }
 
             // Update extension accounts state.
-            addExtensionAccounts({
+            updateExtensionAccounts({
               add: newAccounts,
               remove: accountsToForget,
             });
@@ -323,7 +323,7 @@ export const ExtensionAccountsProvider = ({
   };
 
   // Add an extension account to context state.
-  const addExtensionAccounts = ({
+  const updateExtensionAccounts = ({
     add,
     remove,
   }: {

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
@@ -12,9 +12,8 @@ import {
 import {
   ExtensionAccountsContextInterface,
   ExtensionAccountsProviderProps,
-  Sync,
 } from "./types";
-import { AnyFunction, AnyJson } from "../../utils/types";
+import { Sync, VoidFn } from "../../utils/types";
 import { useImportExtension } from "./useImportExtension";
 import { useExtensions } from "../ExtensionsProvider/useExtensions";
 import { useEffectIgnoreInitial } from "../../base/hooks/useEffectIgnoreInitial";
@@ -61,13 +60,13 @@ export const ExtensionAccountsProvider = ({
     useState<Sync>("unsynced");
 
   // Store extensions whose account subscriptions have been initialised.
-  const [extensionsInitialised, setExtensionsInitialised] = useState<AnyJson[]>(
+  const [extensionsInitialised, setExtensionsInitialised] = useState<string[]>(
     []
   );
   const extensionsInitialisedRef = useRef(extensionsInitialised);
 
   // Store unsubscribe handlers for connected extensions.
-  const unsubs = useRef<Record<string, AnyFunction>>({});
+  const unsubs = useRef<Record<string, VoidFn>>({});
 
   // Helper for setting active account. Ignores if not a valid function.
   const maybeSetActiveAccount = (address: string) => {
@@ -347,7 +346,7 @@ export const ExtensionAccountsProvider = ({
   };
 
   // add an extension id to unsubscribe state.
-  const addToUnsubscribe = (id: string, unsub: AnyFunction) => {
+  const addToUnsubscribe = (id: string, unsub: VoidFn) => {
     unsubs.current[id] = unsub;
   };
 

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
@@ -96,8 +96,6 @@ export const ExtensionAccountsProvider = ({
     // Pre-connect: Inject extensions into `injectedWeb3` if not already injected.
     await handleExtensionAdapters(extensionIds);
 
-    const activeWalletAccount: ImportedAccount | null = null;
-
     // Iterate previously connected extensions and retreive valid `enable` functions.
     // ------------------------------------------------------------------------------
     const rawExtensions = Extensions.getFromIds(extensionIds);
@@ -134,8 +132,12 @@ export const ExtensionAccountsProvider = ({
 
     addExtensionAccount(initialAccounts);
 
-    if (initialAccounts.find(({ address }) => address === activeAccount)) {
-      connectActiveExtensionAccount(activeWalletAccount, connectToAccount);
+    // Connect to the active account if found in initial accounts.
+    const activeAccountInInitial = initialAccounts.find(
+      ({ address }) => address === activeAccount
+    );
+    if (activeAccountInInitial) {
+      connectActiveExtensionAccount(activeAccountInInitial, connectToAccount);
     }
 
     // Initiate account subscriptions for connected extensions.

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
@@ -120,6 +120,7 @@ export const ExtensionAccountsProvider = ({
       Object.entries(enableResults).filter(([, state]) => state.connected)
     );
 
+    // Retrieve  extensions that failed to connect.
     const extensionsWithError = Object.fromEntries(
       Object.entries(enableResults).filter(([, state]) => !state.connected)
     );

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
@@ -161,7 +161,7 @@ export const ExtensionAccountsProvider = ({
     ) => {
       const {
         newAccounts,
-        meta: { accountsToForget },
+        meta: { accountsToRemove },
       } = handleImportExtension(
         extensionId,
         extensionAccountsRef.current,
@@ -174,7 +174,7 @@ export const ExtensionAccountsProvider = ({
       );
 
       // Update added and removed accounts.
-      updateExtensionAccounts({ add: newAccounts, remove: accountsToForget });
+      updateExtensionAccounts({ add: newAccounts, remove: accountsToRemove });
     };
 
     // Try to subscribe to accounts for each connected extension.
@@ -222,7 +222,7 @@ export const ExtensionAccountsProvider = ({
           const handleAccounts = (accounts: ExtensionAccount[]) => {
             const {
               newAccounts,
-              meta: { removedActiveAccount, accountsToForget },
+              meta: { removedActiveAccount, accountsToRemove },
             } = handleImportExtension(
               id,
               extensionAccountsRef.current,
@@ -249,7 +249,7 @@ export const ExtensionAccountsProvider = ({
             // Update extension accounts state.
             updateExtensionAccounts({
               add: newAccounts,
-              remove: accountsToForget,
+              remove: accountsToRemove,
             });
 
             // Update initialised extensions.

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
@@ -117,12 +117,14 @@ export const ExtensionAccountsProvider = ({
 
     // Retrieve the resulting connected extensions only.
     const connectedExtensions = Object.fromEntries(
-      Object.entries(enableResults).filter(([, state]) => state.connected)
+      Array.from(enableResults.entries()).filter(([, state]) => state.connected)
     );
 
     // Retrieve  extensions that failed to connect.
     const extensionsWithError = Object.fromEntries(
-      Object.entries(enableResults).filter(([, state]) => !state.connected)
+      Array.from(enableResults.entries()).filter(
+        ([, state]) => !state.connected
+      )
     );
 
     // Add connected extensions to local storage.

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
@@ -113,22 +113,25 @@ export const ExtensionAccountsProvider = ({
     const extensionsWithError = Extensions.withError(enableResults);
 
     // Add connected extensions to local storage.
-    Object.keys(connectedExtensions).forEach((id) => Extensions.addToLocal(id));
+    Array.from(connectedExtensions.keys()).forEach((id) =>
+      Extensions.addToLocal(id)
+    );
+
+    Array.from(extensionsWithError.entries()).map(([id, state]) => {
+      handleExtensionError(id, state.error);
+    });
+
+    Array.from(connectedExtensions.keys()).map((id) => {
+      setExtensionStatus(id, "connected");
+      updateInitialisedExtensions(id);
+    });
 
     // Initial fetch of extension accounts to populate accounts & extensions state.
     // ----------------------------------------------------------------------------
 
+    // Get full list of imported accounts.
     const initialAccounts =
       await Extensions.getAllAccounts(connectedExtensions);
-
-    Object.entries(extensionsWithError).map(([id, state]) => {
-      handleExtensionError(id, state.error);
-    });
-
-    Object.keys(connectedExtensions).map((id) => {
-      setExtensionStatus(id, "connected");
-      updateInitialisedExtensions(id);
-    });
 
     addExtensionAccount(initialAccounts);
 
@@ -142,7 +145,9 @@ export const ExtensionAccountsProvider = ({
 
     // Initiate account subscriptions for connected extensions.
     // --------------------------------------------------------
-    for (const [id, { extension }] of Object.entries(connectedExtensions)) {
+    for (const [id, { extension }] of Array.from(
+      connectedExtensions.entries()
+    )) {
       const handleAccounts = (accounts: ExtensionAccount[]) => {
         const {
           newAccounts,

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/index.tsx
@@ -160,7 +160,6 @@ export const ExtensionAccountsProvider = ({
     // --------------------------------------------------------
 
     for (const [id, { extension }] of Object.entries(connectedExtensions)) {
-      // Handler for new accounts.
       const handleAccounts = (accounts: ExtensionAccount[]) => {
         const {
           newAccounts,
@@ -168,7 +167,7 @@ export const ExtensionAccountsProvider = ({
         } = handleImportExtension(
           id,
           extensionAccountsRef.current,
-          extension,
+          extension.signer,
           accounts,
           {
             network,
@@ -234,7 +233,7 @@ export const ExtensionAccountsProvider = ({
             } = handleImportExtension(
               id,
               extensionAccountsRef.current,
-              extension,
+              extension.signer,
               accounts,
               { network, ss58 }
             );

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/types.ts
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/types.ts
@@ -25,7 +25,7 @@ export interface ExtensionAccountsProviderProps {
 export interface HandleImportExtension {
   newAccounts: ExtensionAccount[];
   meta: {
-    accountsToForget: ExtensionAccount[];
+    accountsToRemove: ExtensionAccount[];
     removedActiveAccount: MaybeAddress;
   };
 }

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/types.ts
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/types.ts
@@ -8,7 +8,6 @@ import { MaybeAddress, Sync } from "../../utils/types";
 
 export interface ExtensionAccountsContextInterface {
   connectExtensionAccounts: (id?: string) => Promise<boolean>;
-  forgetAccounts: (accounts: ExtensionAccount[]) => void;
   extensionAccountsSynced: Sync;
   extensionAccounts: ImportedAccount[];
 }

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/types.ts
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/types.ts
@@ -4,7 +4,7 @@
 import { ReactNode } from "react";
 import { ExtensionAccount } from "../ExtensionsProvider/types";
 import { ImportedAccount } from "../types";
-import { MaybeAddress } from "../../utils/types";
+import { MaybeAddress, Sync } from "../../utils/types";
 
 export interface ExtensionAccountsContextInterface {
   connectExtensionAccounts: (id?: string) => Promise<boolean>;
@@ -30,7 +30,6 @@ export interface HandleImportExtension {
     removedActiveAccount: MaybeAddress;
   };
 }
-export type Sync = "synced" | "unsynced" | "syncing";
 
 export type NetworkSS58 = {
   network: string;

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/types.ts
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/types.ts
@@ -26,6 +26,7 @@ export interface ExtensionAccountsProviderProps {
 export interface HandleImportExtension {
   newAccounts: ExtensionAccount[];
   meta: {
+    accountsToForget: ExtensionAccount[];
     removedActiveAccount: MaybeAddress;
   };
 }

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/useImportExtension.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/useImportExtension.tsx
@@ -22,7 +22,6 @@ export const useImportExtension = () => {
     currentAccounts: ExtensionAccount[],
     extension: ExtensionInterface,
     newAccounts: ExtensionAccount[],
-    forget: (accounts: ImportedAccount[]) => void,
     { network, ss58 }: NetworkSS58
   ): HandleImportExtension => {
     if (!newAccounts.length) {
@@ -44,7 +43,6 @@ export const useImportExtension = () => {
 
     // Remove `newAccounts` from local external accounts if present.
     const inExternal = getInExternalAccounts(newAccounts, network);
-    forget(inExternal);
 
     // Find any accounts that have been removed from this extension.
     const removedAccounts = currentAccounts
@@ -56,9 +54,6 @@ export const useImportExtension = () => {
       removedAccounts.find(
         ({ address }) => address === getActiveAccountLocal(network, ss58)
       )?.address || null;
-
-    // Commit remove forgotten accounts.
-    forget(removedAccounts);
 
     // Remove accounts that have already been added to `currentAccounts` via another extension.
     newAccounts = newAccounts.filter(
@@ -78,6 +73,7 @@ export const useImportExtension = () => {
     return {
       newAccounts,
       meta: {
+        accountsToForget: [...inExternal, ...removedAccounts],
         removedActiveAccount,
       },
     };

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/useImportExtension.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/useImportExtension.tsx
@@ -4,7 +4,6 @@
 import Keyring from "@polkadot/keyring";
 import { isValidAddress } from "@polkadot-cloud/utils";
 import type { ExtensionAccount } from "../ExtensionsProvider/types";
-import { ImportedAccount } from "../types";
 import { HandleImportExtension, NetworkSS58 } from "./types";
 import { AnyFunction } from "../../utils/types";
 import { getActiveAccountLocal, getInExternalAccounts } from "./utils";
@@ -77,35 +76,7 @@ export const useImportExtension = () => {
     };
   };
 
-  // Get active extension account.
-  //
-  // Checks if the local active account is in the extension.
-  const getActiveExtensionAccount = (
-    { network, ss58 }: NetworkSS58,
-    accounts: ImportedAccount[]
-  ) => {
-    return (
-      accounts.find(
-        ({ address }) => address === getActiveAccountLocal(network, ss58)
-      ) ?? null
-    );
-  };
-
-  // Connect active extension account.
-  //
-  // Connects to active account if it is provided.
-  const connectActiveExtensionAccount = (
-    account: ImportedAccount | null,
-    callback: AnyFunction
-  ) => {
-    if (account !== null) {
-      callback(account);
-    }
-  };
-
   return {
     handleImportExtension,
-    getActiveExtensionAccount,
-    connectActiveExtensionAccount,
   };
 };

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/useImportExtension.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/useImportExtension.tsx
@@ -70,7 +70,7 @@ export const useImportExtension = () => {
     return {
       newAccounts,
       meta: {
-        accountsToForget: [...inExternal, ...removedAccounts],
+        accountsToRemove: [...inExternal, ...removedAccounts],
         removedActiveAccount,
       },
     };

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/useImportExtension.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/useImportExtension.tsx
@@ -3,10 +3,7 @@
 
 import Keyring from "@polkadot/keyring";
 import { isValidAddress } from "@polkadot-cloud/utils";
-import type {
-  ExtensionAccount,
-  ExtensionInterface,
-} from "../ExtensionsProvider/types";
+import type { ExtensionAccount } from "../ExtensionsProvider/types";
 import { ImportedAccount } from "../types";
 import { HandleImportExtension, NetworkSS58 } from "./types";
 import { AnyFunction } from "../../utils/types";
@@ -20,7 +17,7 @@ export const useImportExtension = () => {
   const handleImportExtension = (
     id: string,
     currentAccounts: ExtensionAccount[],
-    extension: ExtensionInterface,
+    signer: AnyFunction,
     newAccounts: ExtensionAccount[],
     { network, ss58 }: NetworkSS58
   ): HandleImportExtension => {
@@ -68,7 +65,7 @@ export const useImportExtension = () => {
       address,
       name,
       source: id,
-      signer: extension.signer,
+      signer,
     }));
     return {
       newAccounts,

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/useImportExtension.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/useImportExtension.tsx
@@ -67,6 +67,7 @@ export const useImportExtension = () => {
       source: id,
       signer,
     }));
+
     return {
       newAccounts,
       meta: {

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/utils.ts
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/utils.ts
@@ -4,7 +4,119 @@
 import { localStorageOrDefault } from "@polkadot-cloud/utils";
 import Keyring from "@polkadot/keyring";
 import { ExtensionAccount } from "../ExtensionsProvider/types";
-import { ExternalAccount } from "../types";
+import {
+  ExtensionEnableResult,
+  ExtensionEnableStatus,
+  ExtensionStatusWithEnable,
+  ExternalAccount,
+} from "../types";
+
+/*------------------------------------------------------------
+   Extension validation utils.
+ ------------------------------------------------------------*/
+
+// Gets all the available extensions and their `enable` property if it exists. If enable does not
+// exist, or the extension is not found, enable will return undefined.
+export const getExtensionsEnable = (
+  extensionIds: string[]
+): ExtensionStatusWithEnable => {
+  const rawExtensions: ExtensionStatusWithEnable = {};
+
+  extensionIds.forEach(async (id) => {
+    // Whether extension is locally stored (previously connected).
+    if (!extensionIsLocal(id)) {
+      rawExtensions[id] = {
+        enable: undefined,
+        status: "extension_not_found",
+      };
+    } else {
+      // Attempt to get extension `enable` property.
+      const { enable } = window.injectedWeb3[id];
+
+      if (enable !== undefined && typeof enable === "function") {
+        rawExtensions[id] = {
+          enable,
+          status: "valid",
+        };
+      } else {
+        rawExtensions[id] = {
+          enable: undefined,
+          status: "enable_invalid",
+        };
+      }
+    }
+  });
+
+  return rawExtensions;
+};
+
+// From the raw extensions, collect those with a particular status.
+export const getExtensionsByStatus = (
+  extensions: ExtensionStatusWithEnable,
+  status: ExtensionEnableStatus
+) => {
+  return Object.fromEntries(
+    Object.entries(extensions).filter(([, entry]) => entry.status === status)
+  );
+};
+
+// Calls `enable` and formats the results of an extension's `enable` function.
+export const enableExtensionsAndFormat = async (
+  extensions: ExtensionStatusWithEnable,
+  dappName: string
+): Promise<Record<string, ExtensionEnableResult>> => {
+  // Call `enable` and accumulate extension statuses (summons extension popup).
+  const results = await Promise.allSettled(
+    Object.values(extensions).map((item) => item.enable(dappName))
+  );
+
+  // Accumulate resulting extensions state after attempting to enable.
+  const extensionsState: Record<string, ExtensionEnableResult> = {};
+
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    const id = Object.keys(extensions)[i];
+
+    if (result.status === "fulfilled") {
+      extensionsState[id] = {
+        extension: result.value,
+        connected: true,
+      };
+    } else if (result.status === "rejected") {
+      extensionsState[id] = {
+        connected: false,
+        error: Error(result.reason),
+      };
+    }
+  }
+
+  return extensionsState;
+};
+
+// Calls `enable` and formats the results of an extension's `enable` function.
+export const getExtensionsAccounts = async (
+  extensions: ExtensionEnableResult[]
+): Promise<ExtensionAccount[]> => {
+  // Call `accounts.get()` and collect results.
+  const results = await Promise.allSettled(
+    extensions.map(({ extension }) => extension.accounts.get())
+  );
+
+  // Accumulate resulting extensions state after attempting to enable.
+  const accounts: ExtensionAccount[] = [];
+
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    if (result.status === "fulfilled") {
+      accounts.push(...result.value);
+    }
+  }
+  return accounts;
+};
+
+/*------------------------------------------------------------
+   localStorage utils.
+ ------------------------------------------------------------*/
 
 // Gets local `active_acount` for a network.
 export const getActiveAccountLocal = (network: string, ss58: number) => {

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/utils.ts
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/utils.ts
@@ -5,6 +5,8 @@ import { localStorageOrDefault } from "@polkadot-cloud/utils";
 import Keyring from "@polkadot/keyring";
 import { ExtensionAccount } from "../ExtensionsProvider/types";
 import { ExternalAccount } from "../types";
+import { NetworkSS58 } from "./types";
+import { AnyFunction } from "../../utils/types";
 
 /*------------------------------------------------------------
    Active account utils.
@@ -19,6 +21,28 @@ export const getActiveAccountLocal = (network: string, ss58: number) => {
     account = keyring.addFromAddress(account).address;
   }
   return account;
+};
+
+// Checks if the local active account is the provided accounts.
+export const getActiveExtensionAccount = (
+  { network, ss58 }: NetworkSS58,
+  accounts: ExtensionAccount[]
+) => {
+  return (
+    accounts.find(
+      ({ address }) => address === getActiveAccountLocal(network, ss58)
+    ) ?? null
+  );
+};
+
+// Connects to active account, and calls an optional callback, if provided.
+export const connectActiveExtensionAccount = (
+  account: ExtensionAccount | null,
+  callback: AnyFunction
+) => {
+  if (account !== null) {
+    callback(account);
+  }
 };
 
 /*------------------------------------------------------------

--- a/packages/cloud-react/lib/connect/ExtensionAccountsProvider/utils.ts
+++ b/packages/cloud-react/lib/connect/ExtensionAccountsProvider/utils.ts
@@ -40,29 +40,29 @@ export const getExtensionsEnable = (extensionIds: string[]): RawExtensions => {
 export const enableExtensionsAndFormat = async (
   extensions: RawExtensions,
   dappName: string
-): Promise<Record<string, ExtensionEnableResult>> => {
+): Promise<Map<string, ExtensionEnableResult>> => {
   // Call `enable` and accumulate extension statuses (summons extension popup).
   const results = await Promise.allSettled(
     Object.values(extensions).map((enable) => enable(dappName))
   );
 
   // Accumulate resulting extensions state after attempting to enable.
-  const extensionsState: Record<string, ExtensionEnableResult> = {};
+  const extensionsState = new Map<string, ExtensionEnableResult>();
 
   for (let i = 0; i < results.length; i++) {
     const result = results[i];
     const id = extensions.keys()[i];
 
     if (result.status === "fulfilled") {
-      extensionsState[id] = {
+      extensionsState.set(id, {
         extension: result.value,
         connected: true,
-      };
+      });
     } else if (result.status === "rejected") {
-      extensionsState[id] = {
+      extensionsState.set(id, {
         connected: false,
         error: result.reason,
-      };
+      });
     }
   }
 

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/index.tsx
@@ -89,7 +89,7 @@ export const ExtensionsProvider = ({ children }: { children: ReactNode }) => {
   // Loops through the supported extensios and checks if they are present in `injectedWeb3`. Adds
   // `installed` status to the extension if it is present.
   const getExtensionsStatus = (snapAvailable: boolean) => {
-    const { injectedWeb3 }: AnyJson = window;
+    const { injectedWeb3 } = window;
 
     const newExtensionsStatus = { ...extensionsStatus };
     if (snapAvailable)

--- a/packages/cloud-react/lib/connect/ExtensionsProvider/types.ts
+++ b/packages/cloud-react/lib/connect/ExtensionsProvider/types.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { ExtensionFeature } from "@polkadot-cloud/assets/types";
-import { AnyJson } from "../../utils/types";
+import { AnyJson, VoidFn } from "../../utils/types";
 import type { FunctionComponent, SVGProps } from "react";
 import { ExternalAccountAddedBy } from "../types";
 
@@ -27,7 +27,7 @@ export interface ExtensionInjected extends ExtensionConfig {
 export interface ExtensionInterface {
   accounts: {
     subscribe: {
-      (a: { (b: ExtensionAccount[]): void }): void;
+      (a: { (b: ExtensionAccount[]): void }): VoidFn;
     };
     get: () => Promise<ExtensionAccount[]>;
   };

--- a/packages/cloud-react/lib/connect/types.ts
+++ b/packages/cloud-react/lib/connect/types.ts
@@ -40,10 +40,9 @@ export interface VaultAccount {
 
 export type ExternalAccountAddedBy = "system" | "user";
 
-export type ExtensionStatusWithEnable = Record<
-  string,
-  (name?: string) => Promise<ExtensionInterface>
->;
+export type RawExtensions = Map<string, RawExtensionEnable>;
+
+export type RawExtensionEnable = (name?: string) => Promise<ExtensionInterface>;
 
 export type ExtensionEnableStatus =
   | "valid"

--- a/packages/cloud-react/lib/connect/types.ts
+++ b/packages/cloud-react/lib/connect/types.ts
@@ -54,11 +54,3 @@ export interface ExtensionEnableResult {
   connected: boolean;
   error?: string;
 }
-
-export type ExtensionEnableResults = Record<
-  string,
-  {
-    enable?: (n?: string) => Promise<ExtensionInterface>;
-    status: ExtensionEnableStatus;
-  }
->;

--- a/packages/cloud-react/lib/connect/types.ts
+++ b/packages/cloud-react/lib/connect/types.ts
@@ -6,7 +6,13 @@ import {
   ExtensionInterface,
 } from "./ExtensionsProvider/types";
 
+/*------------------------------------------------------------
+   Imported account types.
+ ------------------------------------------------------------*/
+
 export type AccountSource = "extension" | "external" | "ledger" | "vault";
+
+export type ExternalAccountAddedBy = "system" | "user";
 
 export type ImportedAccount =
   | ExtensionAccount
@@ -38,7 +44,9 @@ export interface VaultAccount {
   index: number;
 }
 
-export type ExternalAccountAddedBy = "system" | "user";
+/*------------------------------------------------------------
+   Extension import process types.
+ ------------------------------------------------------------*/
 
 export type RawExtensions = Map<string, RawExtensionEnable>;
 
@@ -48,6 +56,8 @@ export type ExtensionEnableStatus =
   | "valid"
   | "extension_not_found"
   | "enable_invalid";
+
+export type ExtensionEnableResults = Map<string, ExtensionEnableResult>;
 
 export interface ExtensionEnableResult {
   extension?: ExtensionInterface;

--- a/packages/cloud-react/lib/connect/types.ts
+++ b/packages/cloud-react/lib/connect/types.ts
@@ -1,7 +1,10 @@
 // Copyright 2023 @polkadot-cloud/library authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { ExtensionAccount } from "./ExtensionsProvider/types";
+import {
+  ExtensionAccount,
+  ExtensionInterface,
+} from "./ExtensionsProvider/types";
 
 export type AccountSource = "extension" | "external" | "ledger" | "vault";
 
@@ -36,3 +39,30 @@ export interface VaultAccount {
 }
 
 export type ExternalAccountAddedBy = "system" | "user";
+
+export type ExtensionStatusWithEnable = Record<
+  string,
+  {
+    enable?: (n?: string) => Promise<ExtensionInterface>;
+    status: ExtensionEnableStatus;
+  }
+>;
+
+export type ExtensionEnableStatus =
+  | "valid"
+  | "extension_not_found"
+  | "enable_invalid";
+
+export interface ExtensionEnableResult {
+  extension?: ExtensionInterface;
+  connected: boolean;
+  error?: Error;
+}
+
+export type ExtensionEnableResults = Record<
+  string,
+  {
+    enable?: (n?: string) => Promise<ExtensionInterface>;
+    status: ExtensionEnableStatus;
+  }
+>;

--- a/packages/cloud-react/lib/connect/types.ts
+++ b/packages/cloud-react/lib/connect/types.ts
@@ -42,10 +42,7 @@ export type ExternalAccountAddedBy = "system" | "user";
 
 export type ExtensionStatusWithEnable = Record<
   string,
-  {
-    enable?: (n?: string) => Promise<ExtensionInterface>;
-    status: ExtensionEnableStatus;
-  }
+  (name?: string) => Promise<ExtensionInterface>
 >;
 
 export type ExtensionEnableStatus =
@@ -56,7 +53,7 @@ export type ExtensionEnableStatus =
 export interface ExtensionEnableResult {
   extension?: ExtensionInterface;
   connected: boolean;
-  error?: Error;
+  error?: string;
 }
 
 export type ExtensionEnableResults = Record<

--- a/packages/cloud-react/lib/utils/types.ts
+++ b/packages/cloud-react/lib/utils/types.ts
@@ -19,6 +19,8 @@ export type ComponentBaseWithClassName = ComponentBase & {
   className?: string;
 };
 
+export type Sync = "synced" | "unsynced" | "syncing";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyApi = any;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This PR refactors `connectActiveExtensions`. The current implementation calls various state updates throughout each extension's import process, which is causing additional re-renders throughout the process, and makes it hard to track where state updates are happening. To make things worse, the more extensions being iterated, the more re-renders there will be.

This PR instead uses `Promise.settleAll` to enable all the extensions, collects the results, and calls another `Promise.settleAll` to fetch each extension's accounts - all before any state updates. The resulting accounts are then injected into account state in one update.

After this, subscriptions are initialised as per usual, but their initial callback will not cause additional state updates, as there will be no new imported accounts to insert after the previous initialisation step.

Note: haven't patched any versions since https://github.com/polkadot-cloud/frontpage/issues/68 needs to be resolved.