### PR TITLE
feat: make odometer values copy friendly

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
   "packages/assets": "0.3.0",
   "packages/cloud-core": "1.2.0",
-  "packages/cloud-react": "0.3.1",
+  "packages/cloud-react": "0.3.2",
   "packages/utils": "0.2.0",
   "builder": "0.2.0",
   "sandbox": "0.2.0"

--- a/packages/cloud-react/lib/complex/Odometer/index.tsx
+++ b/packages/cloud-react/lib/complex/Odometer/index.tsx
@@ -1,9 +1,9 @@
 /* @license Copyright 2024 @polkadot-cloud/library authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
-import { useEffect, useState, createRef, MutableRefObject } from "react";
+import { useEffect, useState, createRef } from "react";
 import "@polkadot-cloud/core/css/complex/Odometer/index.css";
-import { Direction, Props, Status } from "./types";
+import { Digit, DigitRef, Direction, Props, Status } from "./types";
 
 export const Odometer = ({
   value,
@@ -14,7 +14,7 @@ export const Odometer = ({
   zeroDecimals = 0,
 }: Props) => {
   // Store all possible digits.
-  const [allDigits] = useState([
+  const [allDigits] = useState<Digit[]>([
     "comma",
     "dot",
     "0",
@@ -30,10 +30,10 @@ export const Odometer = ({
   ]);
 
   // Store the digits of the current value.
-  const [digits, setDigits] = useState<string[]>([]);
+  const [digits, setDigits] = useState<Digit[]>([]);
 
   // Store digits of the previous value.
-  const [prevDigits, setPrevDigits] = useState<string[]>([]);
+  const [prevDigits, setPrevDigits] = useState<Digit[]>([]);
 
   // Store the status of the odometer (transitioning or stable).
   const [status, setStatus] = useState<Status>("inactive");
@@ -45,21 +45,20 @@ export const Odometer = ({
   const [odometerRef] = useState(createRef<HTMLSpanElement>());
 
   // Store refs of each digit.
-  const [digitRefs, setDigitRefs] = useState<
-    MutableRefObject<HTMLSpanElement>[]
-  >([]);
+  const [digitRefs, setDigitRefs] = useState<DigitRef[]>([]);
 
   // Store refs of each `all` digit.
-  const [allDigitRefs, setAllDigitRefs] = useState<
-    Record<string, MutableRefObject<HTMLSpanElement>>
-  >({});
+  const [allDigitRefs, setAllDigitRefs] = useState<Record<string, DigitRef>>(
+    {}
+  );
+
+  // Transition duration.
+  const DURATION_MS = 750;
+  const DURATION_SECS = `${DURATION_MS / 1000}s`;
 
   // Phase 0: populate `allDigitRefs`.
   useEffect(() => {
-    const all: Record<
-      string,
-      MutableRefObject<HTMLSpanElement>
-    > = Object.fromEntries(
+    const all: Record<string, DigitRef> = Object.fromEntries(
       Object.values(allDigits).map((v) => [`d_${v}`, createRef()])
     );
 
@@ -76,7 +75,7 @@ export const Odometer = ({
         .toString()
         .split("")
         .map((v) => (v === "." ? "dot" : v))
-        .map((v) => (v === "," ? "comma" : v));
+        .map((v) => (v === "," ? "comma" : v)) as Digit[];
 
       setDigits(newDigits);
 
@@ -94,6 +93,10 @@ export const Odometer = ({
   useEffect(() => {
     if (status === "new" && !digitRefs.find((d) => d.current === null)) {
       setStatus("transition");
+
+      setTimeout(() => {
+        setStatus("inactive");
+      }, DURATION_MS);
     }
   }, [status, digitRefs]);
 
@@ -165,7 +168,8 @@ export const Odometer = ({
                   top: 0,
                   left: 0,
                   animationName: direction === "none" ? undefined : animClass,
-                  animationDuration: direction === "none" ? undefined : "0.75s",
+                  animationDuration:
+                    direction === "none" ? undefined : DURATION_SECS,
                   animationFillMode: "forwards",
                   animationTimingFunction: "cubic-bezier(0.1, 1, 0.2, 1)",
                   animationDelay: delay,
@@ -211,6 +215,7 @@ export const Odometer = ({
                     top: 0,
                     height: lineHeight,
                     lineHeight,
+                    width: `${allDigitRefs[`d_${d}`]?.current?.offsetWidth}px`,
                   }}
                 >
                   {d === "dot" ? "." : d === "comma" ? "," : d}

--- a/packages/cloud-react/lib/complex/Odometer/index.tsx
+++ b/packages/cloud-react/lib/complex/Odometer/index.tsx
@@ -1,7 +1,7 @@
 /* @license Copyright 2024 @polkadot-cloud/library authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
-import { useEffect, useState, createRef } from "react";
+import { useEffect, useState, createRef, useRef } from "react";
 import "@polkadot-cloud/core/css/complex/Odometer/index.css";
 import { Digit, DigitRef, Direction, Props, Status } from "./types";
 
@@ -52,6 +52,9 @@ export const Odometer = ({
     {}
   );
 
+  // Keep track of active transitions.
+  const activeTransitionCounter = useRef<number>(0);
+
   // Transition duration.
   const DURATION_MS = 750;
   const DURATION_SECS = `${DURATION_MS / 1000}s`;
@@ -93,9 +96,13 @@ export const Odometer = ({
   useEffect(() => {
     if (status === "new" && !digitRefs.find((d) => d.current === null)) {
       setStatus("transition");
+      activeTransitionCounter.current++;
 
       setTimeout(() => {
-        setStatus("inactive");
+        activeTransitionCounter.current--;
+        if (activeTransitionCounter.current === 0) {
+          setStatus("inactive");
+        }
       }, DURATION_MS);
     }
   }, [status, digitRefs]);

--- a/packages/cloud-react/lib/complex/Odometer/types.ts
+++ b/packages/cloud-react/lib/complex/Odometer/types.ts
@@ -1,6 +1,8 @@
 /* @license Copyright 2024 @polkadot-cloud/library authors & contributors
 SPDX-License-Identifier: GPL-3.0-only */
 
+import { MutableRefObject } from "react";
+
 export interface Props {
   value: number | string;
   wholeColor?: string;
@@ -10,6 +12,22 @@ export interface Props {
   zeroDecimals?: number;
 }
 
-export type Status = "new" | "transition" | "inactive";
+export type Digit =
+  | "comma"
+  | "dot"
+  | "0"
+  | "1"
+  | "2"
+  | "3"
+  | "4"
+  | "5"
+  | "6"
+  | "7"
+  | "8"
+  | "9";
+
+export type DigitRef = MutableRefObject<HTMLSpanElement>;
+
+export type Status = "new" | "inactive" | "transition" | "finished";
 
 export type Direction = "down" | "none";

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-react",
   "license": "GPL-3.0-only",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "contributors": [
     "Ross Bulat<ross@parity.io>",


### PR DESCRIPTION
Addresses https://github.com/polkadot-cloud/library/issues/137

Amends the Odometer component to become inactive again after a transition, which removes all the elements needed to make the transition happen. Now when a user highlights to copy, the actual value is copied. and not the hidden values that existed before.

Also adds some typing.