### PR TITLE
fix: move odometer template digits away from copy-able

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
   "packages/assets": "0.3.0",
   "packages/cloud-core": "1.2.0",
-  "packages/cloud-react": "0.3.2",
+  "packages/cloud-react": "0.3.3",
   "packages/utils": "0.2.0",
   "builder": "0.2.0",
   "sandbox": "0.2.0"

--- a/packages/cloud-core/lib/scss/complex/Odometer/index.scss
+++ b/packages/cloud-core/lib/scss/complex/Odometer/index.scss
@@ -10,13 +10,6 @@ SPDX-License-Identifier: GPL-3.0-only */
   line-height: inherit;
   width: fit-content;
 
-  > .odometer-t-digit {
-    opacity: 0;
-    position: fixed;
-    top: -999%;
-    left: -999%;
-  }
-
   > .odometer-inner {
     display: inline-block;
     vertical-align: bottom;

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-react",
   "license": "GPL-3.0-only",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "contributors": [
     "Ross Bulat<ross@parity.io>",

--- a/sandbox/src/pages/Components.tsx
+++ b/sandbox/src/pages/Components.tsx
@@ -15,6 +15,9 @@ export const Components = () => {
   const [val, setVal] = useState<number>(1201903.456789);
   const updateValue = () => setVal(Number((val + 17491.390013).toFixed(4)));
 
+  const [val2, setVal2] = useState<number>(1201903.456789);
+  const updateValue2 = () => setVal2(Number((val2 + 17491.390013).toFixed(4)));
+
   // Chart colors
   const colors = [
     { value: 60, color: "red" },
@@ -52,6 +55,21 @@ export const Components = () => {
         <button
           type="button"
           onClick={() => updateValue()}
+          style={{ marginTop: "1rem" }}
+        >
+          Trigger Update
+        </button>
+      </div>
+
+      <div style={{ display: "flex" }}>
+        <h3 style={{ margin: "1rem 0 0 0", display: "flex" }}>
+          <Odometer value={new BigNumber(val2).toFormat()} />
+        </h3>
+      </div>
+      <div style={{ display: "flex" }}>
+        <button
+          type="button"
+          onClick={() => updateValue2()}
           style={{ marginTop: "1rem" }}
         >
           Trigger Update


### PR DESCRIPTION
The odometer template digits were in the same `odometer` span container as the values were, which made it quite easy to erroneously copy the template values along with the displayed value when highlighting the value container. This PR moves the template values outside the `odometer` span, with their own inline CSS styles.