### PR TITLE
fix: disallow select transition & template digits

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
   "packages/assets": "0.3.0",
   "packages/cloud-core": "1.2.0",
-  "packages/cloud-react": "0.3.3",
+  "packages/cloud-react": "0.3.4",
   "packages/utils": "0.2.0",
   "builder": "0.2.0",
   "sandbox": "0.2.0"

--- a/packages/cloud-react/lib/complex/Odometer/index.tsx
+++ b/packages/cloud-react/lib/complex/Odometer/index.tsx
@@ -129,6 +129,7 @@ export const Odometer = ({
             position: "fixed",
             top: "-999%",
             left: " -999%",
+            userSelect: "none",
           }}
         >
           {d === "dot" ? "." : d === "comma" ? "," : d}
@@ -187,6 +188,7 @@ export const Odometer = ({
                     animationTimingFunction: "cubic-bezier(0.1, 1, 0.2, 1)",
                     animationDelay: delay,
                     color: foundDecimal ? decimalColor : wholeColor,
+                    userSelect: "none",
                   }}
                 >
                   {digitsToAnimate.map((c, j) => (

--- a/packages/cloud-react/package.json
+++ b/packages/cloud-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polkadot-cloud-react",
   "license": "GPL-3.0-only",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "contributors": [
     "Ross Bulat<ross@parity.io>",


### PR DESCRIPTION
Disallows user to copy template & transition digits of Odometer via `user-select` CSS property.